### PR TITLE
Denote web_port (for monitoring) at session initialization.

### DIFF
--- a/sulley/sessions.py
+++ b/sulley/sessions.py
@@ -154,7 +154,9 @@ class session (pgraph.graph):
         @kwarg crash_threshold     (Optional, def=3) Maximum number of crashes allowed before a node is exhaust
         @type  restart_sleep_time: Integer
         @kwarg restart_sleep_time: Optional, def=300) Time in seconds to sleep when target can't be restarted
-        '''
+        @type  web_port:	   Integer
+        @kwarg web_port:           (Optional, def=26000) Port for monitoring fuzzing campaign via a web browser	
+	'''
 
         # run the parent classes initialization routine first.
         pgraph.graph.__init__(self)


### PR DESCRIPTION
I like to run multiple fuzzing campaigns from a central location, so instead of patching the sulley/sessions.py file every single time, I added web_ports to the @kwargs settings in the sessions.py file.  This allows the user to denote whatever port at session establishment and monitor multiple campaigns via a browser (on different ports of course) vs the default port 26000.

Usage example: sess = sessions.session(session_filename="ftp.session", sleep_time=0.25, web_port=5555)
