### PR TITLE
Bug fix of sessions.py. Add sleep function after sending data in the tra...

### DIFF
--- a/sulley/sessions.py
+++ b/sulley/sessions.py
@@ -865,6 +865,7 @@ class session (pgraph.graph):
             else:
                 sock.sendto(data, (self.targets[0].host, self.targets[0].port))
             self.logger.debug("Packet sent : " + repr(data))
+            time.sleep(0.5)
         except Exception, inst:
             self.logger.error("Socket error, send: %s" % inst)
 


### PR DESCRIPTION
...nsmit function. This is because in some cases, the monitor fails to catch the failure of the process but the process actually crashes. Use sleep function to wait for the process to restart, or sulley will fall into a deadlock and fail to continue sending data.
