### PR TITLE
declare crashbin argument prior to using it

### DIFF
--- a/process_monitor_unix.py
+++ b/process_monitor_unix.py
@@ -246,6 +246,7 @@ if __name__ == "__main__":
 
     log_level = 1
     PORT = None
+    crash_bin = None
     for opt, arg in opts:
         if opt in ("-c", "--crash_bin"):   crash_bin  = arg
         if opt in ("-P", "--port"): PORT = int(arg)


### PR DESCRIPTION
Sorry I forgot this change in my last pull request, now an empty command line call will print out the help message...
