### PR TITLE
Sulley close on "Restarting the target failed, exiting" when target is restarted by process_monitor.py

### DIFF
--- a/process_monitor.py
+++ b/process_monitor.py
@@ -300,6 +300,7 @@ class ProcessMonitorPedrpcServer (pedrpc.server):
 
         self.log("done. target up and running, giving it 5 seconds to settle in.")
         time.sleep(5)
+        return True
 
     def stop_target (self):
         """


### PR DESCRIPTION
When the target crashed, process_monitor restarted the target (function start_target is invoked).

Return value of start_target is used by session.py at line 772. 
If None is returned, restart_target function fails and Sulley closes. (line 700-701).

By adding a return value for start_target in process_monitor.py, It indicates to session.py that the process has been sucessfully restarted and the fuzzing session can continue.
