### PR TITLE
Bug fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+
+
+setup(
+    name='Sulley',
+    download_url='https://github.com/OpenRCE/sulley',
+    packages=['requests', 'sulley', 'sulley.legos', 'sulley.pgraph', 'sulley.utils',
+              'unit_tests', 'utils', 'web'],
+    package_dir={'requests': './requests',
+                 'sulley': './sulley',
+                 'sulley.legos': './sulley/legos',
+                 'sulley.pgraph': './sulley/pgraph',
+                 'sulley.utils': './sulley/utils',
+                 'unit_tests': './unit_tests',
+                 'utils': './utils',
+                 'web': './web'
+                 },
+    install_requires=['pydot2==1.0.33', 'tornado==4.0.2', 'Flask==0.10.1']
+)

--- a/sulley/primitives.py
+++ b/sulley/primitives.py
@@ -184,9 +184,10 @@ class Group(BasePrimitive):
         self.name = name
         self.values = values
         self.s_type = "group"
-        self.value = self.original_value = self.values[0]
 
-        assert self.values > 0, "You can't have an empty value list for your group!"
+        assert len(self.values) > 0, "You can't have an empty value list for your group!"
+
+        self.value = self.original_value = self.values[0]
 
         for val in self.values:
             assert isinstance(val, basestring), "Value list may only contain strings or raw data"

--- a/sulley/primitives.py
+++ b/sulley/primitives.py
@@ -180,12 +180,13 @@ class Group(BasePrimitive):
 
         super(Group, self).__init__()
 
-        assert self.values > 0, "You can't have an empty value list for your group!"
 
         self.name = name
         self.values = values
         self.s_type = "group"
         self.value = self.original_value = self.values[0]
+
+        assert self.values > 0, "You can't have an empty value list for your group!"
 
         for val in self.values:
             assert isinstance(val, basestring), "Value list may only contain strings or raw data"
@@ -624,7 +625,7 @@ class BitField(BasePrimitive):
         if not self.max_num:
             self.max_num = self.to_decimal("1" * width)
 
-        assert isinstance(max_num, (int, long)), "max_num must be an integer!"
+        assert isinstance(self.max_num, (int, long)), "max_num must be an integer!"
 
         if self.full_range:
             # add all possible values.
@@ -744,11 +745,12 @@ class BitField(BasePrimitive):
 
 
 class Byte(BitField):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, value, *args, **kwargs):
         # Inject the one parameter we care to pass in (width)
-        kwargs["width"] = 8
+        width = 8
+        max_num = None
 
-        super(Byte, self).__init__(*args, **kwargs)
+        super(Byte, self).__init__(value, width, max_num, *args, **kwargs)
 
         self.s_type = "byte"
 
@@ -757,11 +759,12 @@ class Byte(BitField):
 
 
 class Word(BitField):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, value, *args, **kwargs):
         # Inject our width argument
-        kwargs["width"] = 16
+        width = 16
+        max_num = None
 
-        super(Word, self).__init__(*args, **kwargs)
+        super(Word, self).__init__(value, width, max_num, *args, **kwargs)
 
         self.s_type = "word"
 
@@ -770,11 +773,12 @@ class Word(BitField):
 
 
 class DWord(BitField):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, value, *args, **kwargs):
         # Inject our width argument
-        kwargs["width"] = 32
+        width = 32
+        max_num = None
 
-        super(DWord, self).__init__(*args, **kwargs)
+        super(DWord, self).__init__(value, width, max_num, *args, **kwargs)
 
         self.s_type = "dword"
 
@@ -783,10 +787,11 @@ class DWord(BitField):
 
 
 class QWord(BitField):
-    def __init__(self, *args, **kwargs):
-        kwargs["width"] = 64
+    def __init__(self, value, *args, **kwargs):
+        width = 64
+        max_num = None
 
-        super(QWord, self).__init__(*args, **kwargs)
+        super(QWord, self).__init__(value, width, max_num, *args, **kwargs)
 
         self.s_type = "qword"
 

--- a/sulley/sessions.py
+++ b/sulley/sessions.py
@@ -342,7 +342,7 @@ class Session(pgraph.Graph):
         fh.write(zlib.compress(cPickle.dumps(data, protocol=2)))
         fh.close()
 
-    def fuzz(self, this_node=None, path=[]):
+    def fuzz(self, this_node=None, path=()):
         """
         Call this routine to get the ball rolling. No arguments are necessary as they are both utilized internally
         during the recursive traversal of the session graph.
@@ -368,6 +368,9 @@ class Session(pgraph.Graph):
                 self.server_init()
             except:
                 return
+
+        if type(path) == tuple:
+            path = list(path)
 
         # TODO: complete parallel fuzzing, will likely have to thread out each target
         target = self.targets[0]
@@ -574,7 +577,7 @@ class Session(pgraph.Graph):
     def log(self, msg, level=1):
         raise Exception("Depreciated!")
 
-    def num_mutations(self, this_node=None, path=[]):
+    def num_mutations(self, this_node=None, path=()):
         """
         Number of total mutations in the graph. The logic of this routine is identical to that of fuzz(). See fuzz()
         for inline comments. The member variable self.total_num_mutations is updated appropriately by this routine.
@@ -591,6 +594,9 @@ class Session(pgraph.Graph):
         if not this_node:
             this_node = self.root
             self.total_num_mutations = 0
+
+        if type(path) == tuple:
+            path = list(path)
 
         for edge in self.edges_from(this_node.id):
             next_node = self.nodes[edge.dst]

--- a/sulley/sessions.py
+++ b/sulley/sessions.py
@@ -342,7 +342,7 @@ class Session(pgraph.Graph):
         fh.write(zlib.compress(cPickle.dumps(data, protocol=2)))
         fh.close()
 
-    def fuzz(self, this_node=None, path=()):
+    def fuzz(self, this_node=None, path=[]):
         """
         Call this routine to get the ball rolling. No arguments are necessary as they are both utilized internally
         during the recursive traversal of the session graph.
@@ -574,7 +574,7 @@ class Session(pgraph.Graph):
     def log(self, msg, level=1):
         raise Exception("Depreciated!")
 
-    def num_mutations(self, this_node=None, path=()):
+    def num_mutations(self, this_node=None, path=[]):
         """
         Number of total mutations in the graph. The logic of this routine is identical to that of fuzz(). See fuzz()
         for inline comments. The member variable self.total_num_mutations is updated appropriately by this routine.
@@ -681,7 +681,7 @@ class Session(pgraph.Graph):
 
         @see: pre_send()
 
-        @type  sock: Socket
+        @type  sock: socket.socket
         @param sock: Connected socket to target
         """
 

--- a/sulley/sessions.py
+++ b/sulley/sessions.py
@@ -369,7 +369,7 @@ class Session(pgraph.Graph):
             except:
                 return
 
-        if type(path) == tuple:
+        if isinstance(path, tuple):
             path = list(path)
 
         # TODO: complete parallel fuzzing, will likely have to thread out each target
@@ -595,7 +595,7 @@ class Session(pgraph.Graph):
             this_node = self.root
             self.total_num_mutations = 0
 
-        if type(path) == tuple:
+        if isinstance(path, tuple):
             path = list(path)
 
         for edge in self.edges_from(this_node.id):

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1,4 +1,4 @@
-{% extends base.html %}
+{% extends "base.html" %}
 {% block body %}
 <!--suppress HtmlUnknownTarget -->
 <div class="main-wrapper">


### PR DESCRIPTION
Bug fixes in sulley/primitives.py, sulley/sessions.py, web/templates/index.html, .
1) primitives.py: enhancements in Byte, Word, DWord and QWord classes not to copy-paste loads of  args led to misplacement of args + two other minor bugs
2) sessions.py: in functions Session.fuzz and Session.num_mutations path parameter's default value as () led to append operation on immutable tuples
3) index.html: omitted quotes in line 1