### PR TITLE
Add "offset" parameter to the s_size funtion.

### DIFF
--- a/docs/generate_epydocs.bat
+++ b/docs/generate_epydocs.bat
@@ -1,1 +1,1 @@
-c:\Python26\python.exe c:\Python26\Scripts\epydoc -o Sulley --css blue --name "Sulley: Fuzzing Framework" --url "http://pedram.openrce.org" ..\sulley
+c:\Python27\python.exe c:\Python27\Scripts\epydoc.py -o Sulley --css blue --name "Sulley: Fuzzing Framework" --url "http://pedram.openrce.org" ..\sulley

--- a/sulley/__init__.py
+++ b/sulley/__init__.py
@@ -208,7 +208,7 @@ def s_repeat (block_name, min_reps=0, max_reps=None, step=1, variable=None, fuzz
     blocks.CURRENT.push(repeat)
 
 
-def s_size (block_name, length=4, endian="<", format="binary", inclusive=False, signed=False, math=None, fuzzable=False, name=None):
+def s_size (block_name, offset=0, length=4, endian="<", format="binary", inclusive=False, signed=False, math=None, fuzzable=False, name=None):
     '''
     Create a sizer block bound to the block with the specified name. You *can not* create a sizer for any
     currently open blocks.
@@ -217,6 +217,8 @@ def s_size (block_name, length=4, endian="<", format="binary", inclusive=False, 
 
     @type  block_name: String
     @param block_name: Name of block to apply sizer to
+    @type  offset:     Integer
+    @param offset:     (Optional, def=0) Offset to calculated size of block
     @type  length:     Integer
     @param length:     (Optional, def=4) Length of sizer
     @type  endian:     Character
@@ -239,7 +241,7 @@ def s_size (block_name, length=4, endian="<", format="binary", inclusive=False, 
     if block_name in blocks.CURRENT.block_stack:
         raise sex.SullyRuntimeError("CAN NOT ADD A SIZE FOR A BLOCK CURRENTLY IN THE STACK")
 
-    size = blocks.size(block_name, blocks.CURRENT, length, endian, format, inclusive, signed, math, fuzzable, name)
+    size = blocks.size(block_name, blocks.CURRENT, offset, length, endian, format, inclusive, signed, math, fuzzable, name)
     blocks.CURRENT.push(size)
 
 

--- a/sulley/blocks.py
+++ b/sulley/blocks.py
@@ -485,10 +485,10 @@ class checksum:
 
         if type(self.algorithm) is str:
             if self.algorithm == "crc32":
-                return struct.pack(self.endian+"L", zlib.crc32(data))
+                return struct.pack(self.endian+"L", (zlib.crc32(data) & 0xFFFFFFFFL))
 
             elif self.algorithm == "adler32":
-                return struct.pack(self.endian+"L", zlib.adler32(data))
+                return struct.pack(self.endian+"L", (zlib.adler32(data) & 0xFFFFFFFFL))
 
             elif self.algorithm == "md5":
                 digest = hashlib.md5(data).digest()
@@ -692,7 +692,7 @@ class size:
     user does not need to be wary of this fact.
     '''
 
-    def __init__ (self, block_name, request, length=4, endian="<", format="binary", inclusive=False, signed=False, math=None, fuzzable=False, name=None):
+    def __init__ (self, block_name, request, offset=0, length=4, endian="<", format="binary", inclusive=False, signed=False, math=None, fuzzable=False, name=None):
         '''
         Create a sizer block bound to the block with the specified name. You *can not* create a sizer for any
         currently open blocks.
@@ -703,6 +703,8 @@ class size:
         @param request:    Request this block belongs to
         @type  length:     Integer
         @param length:     (Optional, def=4) Length of sizer
+        @type  offset:     Integer
+        @param offset:     (Optional, def=0) Offset for calculated size value
         @type  endian:     Character
         @param endian:     (Optional, def=LITTLE_ENDIAN) Endianess of the bit field (LITTLE_ENDIAN: <, BIG_ENDIAN: >)
         @type  format:     String
@@ -721,6 +723,7 @@ class size:
 
         self.block_name    = block_name
         self.request       = request
+        self.offset        = offset
         self.length        = length
         self.endian        = endian
         self.format        = format
@@ -805,7 +808,7 @@ class size:
             else:              self_size = 0
 
             block                = self.request.closed_blocks[self.block_name]
-            self.bit_field.value = self.math(len(block.rendered) + self_size)
+            self.bit_field.value = self.math(len(block.rendered) + self_size + self.offset)
             self.rendered        = self.bit_field.render()
 
         # otherwise, add this sizer block to the requests callback list.


### PR DESCRIPTION
TL;DR I had a block whereby the whole block contents had to be considered
for checksum calculation, but one field (fixed length) not included in the
size field for the block.
Detail:
I was creating a fuzzer for PNG fields whose "Chunks" required the above
consideration, see: http://www.w3.org/TR/PNG/#5Chunk-layout