### PR TITLE
Adding workaround since singal.pause() is missing in Windows.

### DIFF
--- a/sulley/sessions.py
+++ b/sulley/sessions.py
@@ -557,7 +557,7 @@ class session (pgraph.graph):
                 except AttributeError:
                     # signal.pause() is missing for Windows; wait 1ms and loop instead
                     while True:
-                        time.sleep(1)
+                        time.sleep(0.001)
 
 
     ####################################################################################################################

--- a/sulley/sessions.py
+++ b/sulley/sessions.py
@@ -551,8 +551,13 @@ class session (pgraph.graph):
             # if fuzzing is not finished, web interface thread will catch it
             if self.total_mutant_index == self.total_num_mutations:
                 import signal
-                while True:
-                    signal.pause()
+                try:
+                    while True:
+                        signal.pause()
+                except AttributeError:
+                    # signal.pause() is missing for Windows; wait 1ms and loop instead
+                    while True:
+                        time.sleep(1)
 
 
     ####################################################################################################################


### PR DESCRIPTION
OpenRCE/sulley issue #49 
Workaround: If signal.pause() throws an exception, we catch it and loop and sleep for 1ms at a time. Interrupts should be caught within 1ms.