### PR TITLE
network_monitor.py now runs its server in a thread, making Ctrl+C wor…

### DIFF
--- a/network_monitor.py
+++ b/network_monitor.py
@@ -7,6 +7,7 @@ import os
 import pcapy
 import impacket
 import impacket.ImpactDecoder
+import signal
 from sulley import pedrpc
 
 
@@ -254,6 +255,17 @@ if __name__ == "__main__":
 
     try:
         servlet = NetworkMonitorPedrpcServer("0.0.0.0", rpc_port, device, pcap_filter, log_path, log_level)
-        servlet.serve_forever()
+        t = threading.Thread(target=servlet.serve_forever)
+        t.daemon = True
+        t.start()
+        # Now wait in a way that will not block signals like SIGINT
+        try:
+            while True:
+                signal.pause()
+        except AttributeError:
+            # signal.pause() is missing for Windows; wait 1ms and loop instead
+            while True:
+                time.sleep(.001)
+
     except:
         pass


### PR DESCRIPTION
network_monitor.py now runs its server in a thread, making Ctrl+C work in Windows.

This makes killing and restarting the netmon easier.