### PR TITLE
Fix for process_monitor_unix.py start_target()

### DIFF
--- a/process_monitor.py
+++ b/process_monitor.py
@@ -291,6 +291,8 @@ class ProcessMonitorPedrpcServer (pedrpc.server):
     def start_target (self):
         """
         Start up the target process by issuing the commands in self.start_commands.
+
+        @returns True if successful. No failure detection yet.
         """
 
         self.log("starting target process")

--- a/process_monitor_unix.py
+++ b/process_monitor_unix.py
@@ -172,9 +172,11 @@ class nix_process_monitor_pedrpc_server(pedrpc.server):
         self.test_number = test_number
 
     def start_target (self):
-        '''
+        """
         Start up the target process by issuing the commands in self.start_commands.
-        '''
+
+        @returns True if successful. No failure detection yet.
+        """
 
         self.log("starting target process")
         
@@ -184,6 +186,7 @@ class nix_process_monitor_pedrpc_server(pedrpc.server):
         threading.Thread(target=self.dbg.start_monitoring).start()
         self.log("done. target up and running, giving it 5 seconds to settle in.")
         time.sleep(5)
+        return True
 
     def stop_target (self):
         '''


### PR DESCRIPTION
The procmon start_target method is expected to return true if it is successful (see sulley/sessions.py line 772). process_monitor_unix.py failed to do this.

Updated:
 - process_monitor_unix.py start_target method
 - docstrings for both procmon files

Note: I think process_monitor_unix.py is basically broken anyway, as mentioned in one of the issues. But at least now the tests won't halt because Sulley thinks the procmon failed. :)