### PR TITLE
process_monitor.py now accepts relative filenames in -c argument.

### DIFF
--- a/process_monitor.py
+++ b/process_monitor.py
@@ -151,7 +151,7 @@ class ProcessMonitorPedrpcServer (pedrpc.server):
         # initialize the PED-RPC server.
         pedrpc.server.__init__(self, host, port)
 
-        self.crash_filename   = crash_filename
+        self.crash_filename   = os.path.abspath(crash_filename)
         self.proc_name        = proc
         self.ignore_pid       = pid_to_ignore
         self.log_level        = level


### PR DESCRIPTION
process_monitor.py did not expand relative filenames for `--crash_bin` argument. Now it does.

Before:
````
C:\Users\josh\code\sulley>python process_monitor.py -c test -p "calc.exe"
[11:24.03] invalid path specified for crash bin: test
ERR> Error starting RPC server!
````

After (note automatic expansion on line 3):
```
C:\Users\josh\code\sulley>python process_monitor.py -c test -p "calc.exe"
[11:25.41] Process Monitor PED-RPC server initialized:
[11:25.41]       crash file:  C:\Users\josh\code\sulley\test
[11:25.41]       # records:   0
[11:25.41]       proc name:   calc.exe
[11:25.41]       log level:   1
[11:25.41] awaiting requests...
````

The problem line IIRC was process_monitor.py line 167

    if not os.access(os.path.dirname(self.crash_filename), os.X_OK):

`os.access` can take relative paths; `os.path.dirname` cannot:

````
>>> import os
>>> os.access('docs', os.X_OK)
True
>>> os.path.dirname('docs')
''
>>> os.path.dirname(os.path.abspath('docs'))
'/cygdrive/c/Users/josh/code/sulley'
````