### PR TITLE
Netmon refactor fix

### DIFF
--- a/network_monitor.py
+++ b/network_monitor.py
@@ -27,9 +27,10 @@ def create_usage():
     [-l|--log_level LEVEL]    log level (default 1), increase for more verbosity
     [--port PORT]             TCP port to bind this agent to
 
-Network Device List:"""
+Network Device List:
+"""
     for index, pcapy_device in enumerate(pcapy.findalldevs()):
-        IFS.append(device)
+        IFS.append(pcapy_device)
         # if we are on windows, try and resolve the device UUID into an IP address.
         if sys.platform.startswith("win"):
             import _winreg
@@ -218,9 +219,10 @@ class NetworkMonitorPedrpcServer(pedrpc.Server):
 
 
 if __name__ == "__main__":
+    IFS = []
+    device = None
     usage_message = create_usage()
     rpc_port = 26001
-    IFS = []
     opts = None
 
     # parse command line options.
@@ -229,7 +231,6 @@ if __name__ == "__main__":
     except getopt.GetoptError:
         log_error(usage_message)
 
-    device = None
     pcap_filter = ""
     log_path = "./"
     log_level = 1

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,5 @@ setup(
                  'utils': './utils',
                  'web': './web'
                  },
-    install_requires=['pydot2==1.0.33', 'tornado==4.0.2', 'Flask==0.10.1']
+    install_requires=['pydot2==1.0.33', 'tornado==4.0.2', 'Flask==0.10.1', 'pcapy', 'impacket']
 )


### PR DESCRIPTION
### Problem
When running network_monitor.py on Ubuntu, it would crash while trying to create the usage text.

### Solution
`create_usage` was using global variables `IFS` and `device` when they weren't yet declared, and using `device` where it should have been `pcapy_device`. The first commit was the minimal fix.

The second commit sought to eliminate these global variables and clean up a couple warnings. Change summary:
 - new `get_ifs()` method makes `IFS` variable available to main
 - `create_usage()` now takes IFS as an input
 - `IFS` renamed to `ifs` (PEP8)
 - added `main()` method so that main code executes in a local scope. This addressed shadowing issues with the `ifs` variable.
 - added required packages as suggested by PyCharm
 - added docstrings

`create_usage()` is now side-effect free and we're using less global variables!

### Tested
on Ubuntu. Verified docstring works and that network_monitor.py starts and accepts connections. I haven't figure out how to get Tornado on Windows yet so I can't test it there.