### PR TITLE
Fix pcapy.open_live issue on Linux

### DIFF
--- a/network_monitor.py
+++ b/network_monitor.py
@@ -10,6 +10,8 @@ import impacket.ImpactDecoder
 import signal
 from sulley import pedrpc
 
+MAX_PACKET_LENGTH = 65535  # Max packet length for IP capture
+
 
 def log_error(message=None):
     try:
@@ -174,7 +176,7 @@ class NetworkMonitorPedrpcServer (pedrpc.server):
         self.log("initializing capture for test case #%d" % test_number)
 
         # open the capture device and set the BPF filter.
-        self.pcap = pcapy.open_live(self.device, -1, 1, 100)
+        self.pcap = pcapy.open_live(self.device, MAX_PACKET_LENGTH, 1, 100)
         self.pcap.setfilter(self.filter)
 
         # instantiate the capture thread.


### PR DESCRIPTION
Issue #39 
Fixed open_live call to pass 65535 as the maximum packet length instead of -1. -1 was interpreted in a helpful way on some platforms but not on others. 65535 is cross-platform.

Removed magic number.