### PR TITLE
Delim self.original_value initialization fix

### DIFF
--- a/sulley/primitives.py
+++ b/sulley/primitives.py
@@ -109,7 +109,7 @@ class Delim(BasePrimitive):
 
         self.fuzzable = fuzzable
         self.name = name
-        self.value = value
+        self.value = self.original_value = value
         self.s_type = "delim"  # for ease of object identification
 
         if self.value:


### PR DESCRIPTION
This was a small regression in the sulley_refactor branch that resulted in a crash. The fix is trivial but tracking it down took a while. Those automated unit tests sure would be nice... :)