### PR TITLE
Alternative interfaces

### DIFF
--- a/sulley/fuzz_logger.py
+++ b/sulley/fuzz_logger.py
@@ -1,0 +1,79 @@
+import ifuzz_logger
+import os
+import errno
+
+
+class FuzzLogger(ifuzz_logger.IFuzzLogger):
+    """
+    IFuzzLogger that saves sent and received data to files within a directory.
+
+    File format is: <mutation nubmer>-(rx|tx)-<sequence number>.txt
+    """
+
+    def __init__(self, path):
+        """
+        :param path: Directory in which to save fuzz data.
+        """
+        self._path = path
+        self._current_id = ''
+        self._rx_count = 0
+        self._tx_count = 0
+
+        # mkdir -p self._path
+        try:
+            os.makedirs(self._path)
+        except OSError as exc:
+            if exc.errno == errno.EEXIST and os.path.isdir(path):
+                pass
+            else:
+                raise
+
+    def open_test_case(self, test_case_id):
+        """
+        Open a test case - i.e., a fuzzing mutation.
+
+        :param test_case_id: Test case name/number. Should be unique.
+
+        :return: None
+        """
+        self._current_id = str(test_case_id)
+        self._rx_count = 0
+        self._tx_count = 0
+
+    def log_send(self, data):
+        """
+        Records data as about to be sent to the target.
+
+        :param data: Transmitted data
+        :type data: buffer
+
+        :return: None
+        :rtype: None
+        """
+        self._tx_count += 1
+
+        filename = "{0}-tx-{1}.txt".format(self._current_id, self._tx_count)
+        full_name = os.path.join(self._path, filename)
+
+        # Write data in binary mode to avoid newline conversion
+        with open(full_name, "wb") as file_handle:
+            file_handle.write(data)
+
+    def log_recv(self, data):
+        """
+        Records data as having been received from the target.
+
+        :param data: Received data.
+        :type data: buffer
+
+        :return: None
+        :rtype: None
+        """
+        self._rx_count += 1
+
+        filename = "{0}-rx-{1}.txt".format(self._current_id, self._tx_count)
+        full_name = os.path.join(self._path, filename)
+
+        # Write data in binary mode to avoid newline conversion
+        with open(full_name, "wb") as file_handle:
+            file_handle.write(data)

--- a/sulley/ifuzz_logger.py
+++ b/sulley/ifuzz_logger.py
@@ -1,0 +1,45 @@
+import abc
+
+
+class IFuzzLogger(object):
+    """
+    Abstract class for logging fuzz data. Allows for logging approaches.
+    """
+    __metaclass__ = abc.ABCMeta
+
+    @abc.abstractmethod
+    def open_test_case(self, test_case_id):
+        """
+        Open a test case - i.e., a fuzzing mutation.
+
+        :param test_case_id: Test case name/number. Should be unique.
+
+        :return: None
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def log_send(self, data):
+        """
+        Records data as about to be sent to the target.
+
+        :param data: Transmitted data
+        :type data: buffer
+
+        :return: None
+        :rtype: None
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def log_recv(self, data):
+        """
+        Records data as having been received from the target.
+
+        :param data: Received data.
+        :type data: buffer
+
+        :return: None
+        :rtype: None
+        """
+        raise NotImplementedError

--- a/sulley/itarget_connection.py
+++ b/sulley/itarget_connection.py
@@ -1,0 +1,51 @@
+import abc
+
+
+class ITargetConnection(object):
+    """
+    Interface for connections to fuzzing targets.
+    Target connections may be opened and closed multiple times. You must open before using send/recv and close
+    afterwards.
+    """
+    __metaclass__ = abc.ABCMeta
+
+    @abc.abstractmethod
+    def close(self):
+        """
+        Close connection.
+
+        :return: None
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def open(self):
+        """
+        Opens connection to the target. Make sure to call close!
+
+        :return: None
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def recv(self, max_bytes):
+        """
+        Receive up to max_bytes data.
+
+        :param max_bytes: Maximum number of bytes to receive.
+        :type max_bytes: int
+
+        :return: Received data. bytes('') if no data is received.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def send(self, data):
+        """
+        Send data to the target.
+
+        :param data: Data to send.
+
+        :return: None
+        """
+        raise NotImplementedError

--- a/sulley/serial_connection.py
+++ b/sulley/serial_connection.py
@@ -5,18 +5,24 @@ import serial
 class SerialConnection(itarget_connection.ITargetConnection):
     """
     ITargetConnection implementation using serial ports.
+
+    Messages are time-delimited, based on a parameter given to the constructor.
     """
-    def __init__(self, port, baudrate):
+
+    def __init__(self, port, baudrate, message_separator_time=0.300):
         """
-        @type  port: int | str
-        @param port: Serial port name or number.
-        @type baudrate: int
-        @param baudrate: Baud rate for port.
+        @type  port:                   int | str
+        @param port:                   Serial port name or number.
+        @type baudrate:                int
+        @param baudrate:               Baud rate for port.
+        @type message_separator_time:  float
+        @param message_separator_time: The amount of time to wait before considering a reply from the target complete.
         """
         self._device = None
         self.port = port
         self.baudrate = baudrate
         self.logger = None
+        self.message_separator_time = message_separator_time
 
     def close(self):
         """
@@ -44,7 +50,7 @@ class SerialConnection(itarget_connection.ITargetConnection):
         :return: Received data.
         """
 
-        self._device.timeout = 0.010
+        self._device.timeout = self.message_separator_time
 
         fragment = self._device.read(size=1024)
         data = fragment
@@ -55,7 +61,6 @@ class SerialConnection(itarget_connection.ITargetConnection):
             fragment = self._device.read(size=1024)
             data += fragment
 
-        print("recv:{0}".format(data))
         return data
 
     def send(self, data):
@@ -66,7 +71,6 @@ class SerialConnection(itarget_connection.ITargetConnection):
 
         :return: None
         """
-        print("send:{0}".format(data))
         self._device.write(data)
 
     def set_logger(self, logger):

--- a/sulley/serial_connection.py
+++ b/sulley/serial_connection.py
@@ -1,0 +1,81 @@
+import itarget_connection
+import serial
+
+
+class SerialConnection(itarget_connection.ITargetConnection):
+    """
+    ITargetConnection implementation using serial ports.
+    """
+    def __init__(self, port, baudrate):
+        """
+        @type  port: int | str
+        @param port: Serial port name or number.
+        @type baudrate: int
+        @param baudrate: Baud rate for port.
+        """
+        self._device = None
+        self.port = port
+        self.baudrate = baudrate
+        self.logger = None
+
+    def close(self):
+        """
+        Close connection to the target.
+
+        :return: None
+        """
+        self._device.close()
+
+    def open(self):
+        """
+        Opens connection to the target. Make sure to call close!
+
+        :return: None
+        """
+        self._device = serial.Serial(port=self.port, baudrate=self.baudrate)
+
+    def recv(self, max_bytes):
+        """
+        Receive up to max_bytes data from the target.
+
+        :param max_bytes: Maximum number of bytes to receive.
+        :type max_bytes: int
+
+        :return: Received data.
+        """
+
+        self._device.timeout = 0.010
+
+        fragment = self._device.read(size=1024)
+        data = fragment
+
+        # Serial ports can be slow and render only a few bytes at a time.
+        # Therefore, we keep reading until we get nothing, in hopes of getting a full packet.
+        while fragment:
+            fragment = self._device.read(size=1024)
+            data += fragment
+
+        print("recv:{0}".format(data))
+        return data
+
+    def send(self, data):
+        """
+        Send data to the target. Only valid after calling open!
+
+        :param data: Data to send.
+
+        :return: None
+        """
+        print("send:{0}".format(data))
+        self._device.write(data)
+
+    def set_logger(self, logger):
+        """
+        Set this object's (and it's aggregated classes') logger.
+
+        :param logger: Logger to use.
+        :type logger: logging.Logger
+
+        :return: None
+        """
+        self.logger = logger

--- a/sulley/serial_target.py
+++ b/sulley/serial_target.py
@@ -1,0 +1,30 @@
+import sessions
+import serial_connection
+
+
+class SerialTarget(sessions.Target):
+    """
+    Target class that uses a SerailConnection.
+    Encapsulates connection logic for the target, as well as pedrpc connection logic.
+
+    Contains a logger which is configured by Session.add_target().
+    """
+
+    def __init__(self, port=0, baudrate=9600):
+        """
+        @type  port: int | str
+        @param port: Serial port name or number.
+        @type baudrate: int
+        @param baudrate: Baud rate for port.
+        """
+        super(SerialTarget, self).__init__(host="", port=1)
+
+        self.target_connection = serial_connection.SerialConnection(port=port, baudrate=baudrate)
+
+        # set these manually once target is instantiated.
+        self.netmon = None
+        self.procmon = None
+        self.vmcontrol = None
+        self.netmon_options = {}
+        self.procmon_options = {}
+        self.vmcontrol_options = {}

--- a/sulley/serial_target.py
+++ b/sulley/serial_target.py
@@ -4,22 +4,27 @@ import serial_connection
 
 class SerialTarget(sessions.Target):
     """
-    Target class that uses a SerailConnection.
+    Target class that uses a SerailConnection. Serial messages are assumed to be time-separated.
     Encapsulates connection logic for the target, as well as pedrpc connection logic.
 
     Contains a logger which is configured by Session.add_target().
     """
 
-    def __init__(self, port=0, baudrate=9600):
+    def __init__(self, port=0, baudrate=9600, message_separator_time=0.300):
         """
-        @type  port: int | str
-        @param port: Serial port name or number.
-        @type baudrate: int
-        @param baudrate: Baud rate for port.
+        @type  port:                   int | str
+        @param port:                   Serial port name or number.
+        @type baudrate:                int
+        @param baudrate:               Baud rate for port.
+        @type message_separator_time:  float
+        @param message_separator_time: The amount of time to wait before considering a reply from the target complete.
         """
         super(SerialTarget, self).__init__(host="", port=1)
 
-        self.target_connection = serial_connection.SerialConnection(port=port, baudrate=baudrate)
+        self._target_connection = serial_connection.SerialConnection(
+            port=port,
+            baudrate=baudrate,
+            message_separator_time=message_separator_time)
 
         # set these manually once target is instantiated.
         self.netmon = None

--- a/sulley/socket_connection.py
+++ b/sulley/socket_connection.py
@@ -1,0 +1,127 @@
+import itarget_connection
+import socket
+import ssl
+import httplib
+
+import sex
+from helpers import get_max_udp_size
+
+
+class SocketConnection(itarget_connection.ITargetConnection):
+    """
+    ITargetConnection implementation using sockets. Supports UDP, TCP, SSL.
+    """
+    def __init__(self, host, port, proto="tcp", bind=None, timeout=5.0):
+        """
+        @type  host: str
+        @param host: Hostname or IP address of target system
+        @type  port: int
+        @param port: Port of target service
+        @type  proto:              str
+        @kwarg proto:              (Optional, def="tcp") Communication protocol ("tcp", "udp", "ssl")
+        @type  bind:               tuple (host, port)
+        @kwarg bind:               (Optional, def=random) Socket bind address and port
+        @type  timeout:            float
+        @kwarg timeout:            (Optional, def=5.0) Seconds to wait for a send/recv prior to timing out
+        """
+        self.max_udp = get_max_udp_size()
+
+        self.host = host
+        self.port = port
+        self.bind = bind
+        self.ssl = False
+        self.timeout = timeout
+        self.proto = proto.lower()
+        self._sock = None
+        self.logger = None
+
+        if self.proto == "tcp":
+            self.proto = socket.SOCK_STREAM
+
+        elif self.proto == "ssl":
+            self.proto = socket.SOCK_STREAM
+            self.ssl = True
+
+        elif self.proto == "udp":
+            self.proto = socket.SOCK_DGRAM
+
+        else:
+            raise sex.SullyRuntimeError("INVALID PROTOCOL SPECIFIED: %s" % self.proto)
+
+    def close(self):
+        """
+        Close connection to the target.
+
+        :return: None
+        """
+        self._sock.close()
+
+    def open(self):
+        """
+        Opens connection to the target. Make sure to call close!
+
+        :return: None
+        """
+        self._sock = socket.socket(socket.AF_INET, self.proto)
+
+        if self.bind:
+            self._sock.bind(self.bind)
+
+        self._sock.settimeout(self.timeout)
+
+        # Connect is needed only for TCP stream
+        if self.proto == socket.SOCK_STREAM:
+            self._sock.connect((self.host, self.port))
+
+        # if SSL is requested, then enable it.
+        if self.ssl:
+            ssl_sock = ssl.wrap_socket(self._sock)
+            self._sock = httplib.FakeSocket(self._sock, ssl_sock)
+
+    def recv(self, max_bytes):
+        """
+        Receive up to max_bytes data from the target.
+
+        :param max_bytes: Maximum number of bytes to receive.
+        :type max_bytes: int
+
+        :return: Received data.
+        """
+        try:
+            return self._sock.recv(max_bytes)
+        except socket.timeout:
+            return bytes('')
+
+    def send(self, data):
+        """
+        Send data to the target. Only valid after calling open!
+
+        :param data: Data to send.
+
+        :return: None
+        """
+        # TCP/SSL
+        if self.proto == socket.SOCK_STREAM:
+            self._sock.send(data)
+        # UDP
+        elif self.proto == socket.SOCK_DGRAM:
+            # TODO: this logic does not prevent duplicate test cases, need to address this in the future.
+            # If our data is over the max UDP size for this platform, truncate before sending
+            if len(data) > self.max_udp:
+                self.logger.debug("Too much data for UDP, truncating to %d bytes" % self.max_udp)
+                data = data[:self.max_udp]
+
+            self._sock.sendto(data, (self.host, self.port))
+
+        self.logger.debug("Packet sent : " + repr(data))
+
+    def set_logger(self, logger):
+        """
+        Set this object's (and it's aggregated classes') logger.
+
+        :param logger: Logger to use.
+        :type logger: logging.Logger
+
+        :return: None
+        """
+        self.logger = logger


### PR DESCRIPTION
See Issue #92 Feature Proposal: Alternative Interfaces .

Goal:
- Allow non-socket interfaces (requires abstracting out connection/transmission code so that another object can be swapped in).
- Add serial interface.
- Allow basic logging for serial rx/tx data.

Changes:
- `Session` class:
    - Refactored out connection and send/recv functionality. This now happens through `Target.open()`, `Target.send()`, `Target.recv()`, `Target.close()`.
    - Added `fuzz_data_logger` constructor param (see below).
- Target class:
    - Added open, send, recv, close methods.
    - Added host, port, proto, bind, timeout to constructor parameters.
- Connection classes:
    - `ITargetConnection` is the generic interface for connections.
    - `SocketConnection` is where the existing sockets code went.
    - `SerialConnection` is self-explanatory.
- `SerialTarget` class: Inherits from Target and uses a `SerialConnection`. Simple class.
- `IFuzzLogger` and `FuzzLogger` define the interface and one implementation for logging sent and received fuzz data.
    - A future implementation could use the pcap format, eliminating the need for a separate network monitor.
    - This is used in the Session class, which calls `open_test_case` to signal a new mutation, and in the `Target` class to record sent and received data.

Example:

Here is a complete usage example for throwing data at a serial device. Files will be stored in `./exploration-local-caps/`.
````python
#!/usr/bin/env python
from sulley import *
from sulley import sessions
from sulley import serial_target
from sulley import fuzz_logger
import logging

# Exploratory fuzzing for some mystery device

# Fuzz data logger:
logger = fuzz_logger.FuzzLogger(path="exploration-local-caps")

# Serial Target:
target = serial_target.SerialTarget(port=1, baudrate=19200, message_separator_time=.3)

# Session
sess = sessions.Session(session_filename="exploration.session", sleep_time=0.25, log_level=logging.INFO,
                        fuzz_data_logger=logger)
sess.add_target(target)

# Fuzz plan
s_initialize("explore")
s_string("???")
sess.connect(s_get("explore"))

print "Geronimo!"
sess.fuzz()
````

There is no error detection yet, but it's an important start.