### PR TITLE
Fixed procmon bug from refactor

### DIFF
--- a/sulley/sessions.py
+++ b/sulley/sessions.py
@@ -720,6 +720,9 @@ class Session(pgraph.Graph):
 
         @type  target: session.target
         @param target: Target we are restarting
+
+        @rtype : bool
+        @returns: False if restart failed (such that we know it failed). True otherwise.
         """
 
         # vm restarting is the preferred method so try that first.
@@ -750,6 +753,8 @@ class Session(pgraph.Graph):
 
         # pass specified target parameters to the PED-RPC server to re-establish connections.
         target.pedrpc_connect()
+
+        return True
 
     def server_init(self):
         """


### PR DESCRIPTION
Fixed bug introduced by refactor. Sulley would indicate that a target failed to restart, even when it didn't.

`Session.restart_target` is used (by `poll_pedrpc`) as if it returns True or False. It actually returned None or False.

In `master`, `sulley/sessions.py` line 705 revision 54bdbbebdc2348a0c845d8425027f5557d05d515
````python
            if self.restart_target(target, stop_first=False) == False:
                self.logger.critical("Restarting the target failed, exiting.")
                ...
````

In `sulley_refactor`, `sulley/sessions.py` line 673 revision 256c21d47624b67d44f28926ac905a5f8d58b93c
````python
            if not self.restart_target(target, stop_first=False):
                self.logger.critical("Restarting the target failed, exiting.")
                ...
````

The problem is that restart_target never returned True if it succeeded. It returned None. This worked before, since `None == False` is False. But `not None` is True. I updated `restart_target` to return True if it succeeds.
````python
>>> None == False
False
>>> not None
True
````