### PR TITLE
Sully Refactor Web Fixes

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -17,7 +17,7 @@ def commify(number):
 @app.route("/togglepause")
 def pause():
     # Flip our state
-    app.session.pause_flag = not app.session.pause_flag
+    app.session.is_paused = not app.session.is_paused
     return redirect('/')
 
 

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -4,7 +4,7 @@
   <head>
     <!--<meta http-equiv="refresh" content="5">-->
     <title>Sulley Fuzz Control</title>
-    <link rel="stylesheet" type="text/css" href="static/css/sulley.css">
+    <link rel="stylesheet" type="text/css" href="/static/css/sulley.css">
   </head>
   <body>
   {% block body %} {% endblock %}

--- a/web/templates/view_crash.html
+++ b/web/templates/view_crash.html
@@ -1,4 +1,4 @@
-{% extends base.html %}
+{% extends "base.html" %}
 {% block body %}
 <div class="main-wrapper">
   <table border=0 cellpadding=5 cellspacing=0 width=750>
@@ -12,9 +12,7 @@
           </tr>
           <tr bgcolor="#111111">
             <td colspan=2 align="center">
-              <pre>
-                {{ crashinfo }}
-              </pre>
+              <pre>{{ crashinfo }}</pre>
             </td>
           </tr>
         </table>


### PR DESCRIPTION
Fixed a few web bugs from Sulley refactor:
 - app.py referenced Session.paused_flag which is actually named Session.is_paused
 - view_crash.html had a syntax error when referencing base.html (missing double quotes); fix taken from index.html
 - base.html was referencing sulley.css with an unrooted relative path, which failed because view_crash works like its own directory
 - removed extra whitespace in base.html's pre tag.