### PR TITLE
ZeroDivision Error fix in web/app.py

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -56,7 +56,10 @@ def index():
     mutant_index = float(app.session.fuzz_node.mutant_index)
     num_mutations = float(app.session.fuzz_node.num_mutations())
 
-    progress_current = mutant_index / num_mutations
+    try:
+        progress_current = mutant_index / num_mutations
+    except ZeroDivisionError:
+        progress_current = 0
     num_bars = int(progress_current * 50)
     progress_current_bar = "[" + "=" * num_bars + "&nbsp;" * (50 - num_bars) + "]"
     progress_current = "%.3f%%" % (progress_current * 100)
@@ -64,7 +67,10 @@ def index():
     total_mutant_index = float(app.session.total_mutant_index)
     total_num_mutations = float(app.session.total_num_mutations)
 
-    progress_total = total_mutant_index / total_num_mutations
+    try:
+        progress_total = total_mutant_index / total_num_mutations
+    except ZeroDivisionError:
+        progress_total = 0
     num_bars = int(progress_total * 50)
     progress_total_bar = "[" + "=" * num_bars + "&nbsp;" * (50 - num_bars) + "]"
     progress_total = "%.3f%%" % (progress_total * 100)


### PR DESCRIPTION
To reproduce error:
 - Pause a test.
 - Quit Sulley.
 - Restart Sulley.
 - Load webpage and observe `ZeroDivisionError` on the console.

This is the same bug as pull request #82, except in the `sulley_refactor` branch.

Root cause note: This happens because something or other isn't initialized nicely in sessions.py when the server is paused. I can enter an issue to track this if desired.