### PR TITLE
view_crash.html template fix

### DIFF
--- a/web/templates/view_crash.html
+++ b/web/templates/view_crash.html
@@ -12,9 +12,7 @@
           </tr>
           <tr bgcolor="#111111">
             <td colspan=2 align="center">
-              <pre>
-                {{ crashinfo }}
-              </pre>
+              <pre>{{ crashinfo.decode('utf-8', errors='replace') }}</pre>
             </td>
           </tr>
         </table>


### PR DESCRIPTION
Queuing up another fix, just so I don't forget it.

view_crash.html template now works with arbitrary data, and doesn't crash with invalid Unicode.

This would crash for me when invalid bytes got into my crash report; they are now replaced.