### PR TITLE
Support for IPv6 targets

### DIFF
--- a/sulley/sessions.py
+++ b/sulley/sessions.py
@@ -461,7 +461,8 @@ class session (pgraph.graph):
 
                         try:
                             # establish a connection to the target.
-                            sock = socket.socket(socket.AF_INET, self.proto)
+                            (family, socktype, proto, canonname, sockaddr)=socket.getaddrinfo(target.host, target.port)[0]
+                            sock = socket.socket(family, self.proto)
                         except Exception, e:
                             error_handler(e, "failed creating socket", target)
                             continue


### PR DESCRIPTION
This small patch adds support for IPv6 targets by using socket.getaddrinfo(..)[0] to determine the socket family - AF_INET or AF_INET6