### PR TITLE
Add setup.py for easy installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+from setuptools import setup
+
+setup(
+    name='sulley',
+    version=0.1,
+    description='A pure-python fully automated'
+                'and unattended fuzzing framework.',
+    author='OpenRCE',
+    packages=['sulley', 'sulley.legos', 'sulley.pgraph', 'sulley.utils'],
+    install_requires=[
+        'pydot'
+    ]
+)


### PR DESCRIPTION
Allows users to install sulley by simply typing `python setup.py install`.