### PR TITLE
docs: fix simple typo, varous -> various

### DIFF
--- a/sulley/sessions.py
+++ b/sulley/sessions.py
@@ -564,7 +564,7 @@ class session (pgraph.graph):
     ####################################################################################################################
     def import_file (self):
         '''
-        Load varous object values from disk.
+        Load various object values from disk.
 
         @see: export_file()
         '''


### PR DESCRIPTION
There is a small typo in sulley/sessions.py.

Should read `various` rather than `varous`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md